### PR TITLE
Minor fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,7 +1124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
-name = "rusty-quack"
+name = "rusty_quack"
 version = "0.1.0"
 dependencies = [
  "duckdb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rusty-quack"
+name = "rusty_quack"
 version = "0.1.0"
 edition = "2021"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,9 +85,11 @@ impl VTab for HelloVTab {
     }
 }
 
+const EXTENSION_NAME: &str = env!("CARGO_PKG_NAME");
+
 #[duckdb_entrypoint_c_api(ext_name = "rusty_quack", min_duckdb_version = "v0.0.1")]
 pub unsafe fn extension_entrypoint(con: Connection) -> Result<(), Box<dyn Error>> {
-    con.register_table_function::<HelloVTab>("rusty_quack")
+    con.register_table_function::<HelloVTab>(EXTENSION_NAME)
         .expect("Failed to register hello table function");
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ impl VTab for HelloVTab {
 }
 
 #[duckdb_entrypoint_c_api(ext_name = "rusty_quack", min_duckdb_version = "v0.0.1")]
-pub unsafe fn ExtensionEntrypoint(con: Connection) -> Result<(), Box<dyn Error>> {
+pub unsafe fn extension_entrypoint(con: Connection) -> Result<(), Box<dyn Error>> {
     con.register_table_function::<HelloVTab>("rusty_quack")
         .expect("Failed to register hello table function");
     Ok(())


### PR DESCRIPTION
Fix warning connected to function name not being snake-case.

Fix package name to be the same as extension name (this I somehow need on Wasm side, and I think it's just cleaner).

I experimented with having the name also inherited in `src/lib.rs`, and one of the two occurrences I managed, for the other it might require adapting the other create, I haven't found a proper way.