### PR TITLE
Add wasm builds

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -20,4 +20,4 @@ jobs:
       ci_tools_version: main
       extension_name: rusty_quack
       extra_toolchains: rust;python3
-      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools'
+      exclude_archs: 'windows_amd64_rtools'

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -20,4 +20,4 @@ jobs:
       ci_tools_version: main
       extension_name: rusty_quack
       extra_toolchains: rust;python3
-      exclude_archs: 'windows_amd64_rtools'
+      exclude_archs: 'wasm_threads;windows_amd64_rtools'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,11 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib"]
 
+[[example]]
+name = "rusty-quack"
+path = "src/wasm_lib.rs"
+crate-type = ["staticlib"]
+
 [dependencies]
 duckdb = { version = "1.1.1", features = ["vtab-loadable"] }
 duckdb-loadable-macros = "0.1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [[example]]
-name = "rusty-quack"
+name = "rusty_quack"
 path = "src/wasm_lib.rs"
 crate-type = ["staticlib"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [[example]]
+# crate-type can't be (at the moment) be overriden for specific targets
+# src/wasm_lib.rs forwards to src/lib.rs so that we can change from cdylib
+# (that is needed while compiling natively) to staticlib (needed since the
+# actual linking will be done via emcc
 name = "rusty_quack"
 path = "src/wasm_lib.rs"
 crate-type = ["staticlib"]

--- a/Makefile
+++ b/Makefile
@@ -23,15 +23,3 @@ test_release: test_extension_release
 
 clean: clean_build clean_rust
 clean_all: clean_configure clean
-
-wasm_mvp: export DUCKDB_PLATFORM = wasm_mvp
-wasm_mvp: configure release
-	cp -r build/release build/wasm_mvp
-
-wasm_eh: export DUCKDB_PLATFORM = wasm_eh
-wasm_eh: configure release
-	cp -r build/release build/wasm_eh
-
-wasm_threads: export DUCKDB_PLATFORM = wasm_coi
-wasm_threads: configure release
-	cp -r build/release build/wasm_threads

--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,12 @@ clean_all: clean_configure clean
 
 wasm_mvp: export DUCKDB_PLATFORM = wasm_mvp
 wasm_mvp: configure release
+	cp -r build/release build/wasm_mvp
 
 wasm_eh: export DUCKDB_PLATFORM = wasm_eh
 wasm_eh: configure release
+	cp -r build/release build/wasm_eh
 
 wasm_threads: export DUCKDB_PLATFORM = wasm_coi
 wasm_threads: configure release
+	cp -r build/release build/wasm_threads

--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,12 @@ test_release: test_extension_release
 
 clean: clean_build clean_rust
 clean_all: clean_configure clean
+
+wasm_mvp: export DUCKDB_PLATFORM = wasm_mvp
+wasm_mvp: configure release
+
+wasm_eh: export DUCKDB_PLATFORM = wasm_eh
+wasm_eh: configure release
+
+wasm_threads: export DUCKDB_PLATFORM = wasm_coi
+wasm_threads: configure release

--- a/src/wasm_lib.rs
+++ b/src/wasm_lib.rs
@@ -1,0 +1,3 @@
+#![allow(special_module_name)]
+
+mod lib;

--- a/src/wasm_lib.rs
+++ b/src/wasm_lib.rs
@@ -1,3 +1,14 @@
 #![allow(special_module_name)]
 
 mod lib;
+
+// To build the Wasm target, a `staticlib` crate-type is required
+//
+// This is different than the default needed in native, and there is
+// currently no way to select crate-type depending on target.
+//
+// This file sole purpose is remapping the content of lib as an
+// example, do not change the content of the file.
+//
+// To build the Wasm target explicitly, use:
+//   cargo build --example $PACKAGE_NAME


### PR DESCRIPTION
This might require another round of polishing, and possible some more refactoring to move stuff to `extension-ci-tools`.

This is on top of #1, I would say that can be checked independently.

One problem I bumped against is that seemingly you can't feature-select the crate type, and that needs to be `staticlib` for wasm and `cdylib` for native.
Trick I copied from https://github.com/linebender/xilem/blob/6af19494cd985e6ac2e914e73d701fe78752a3fc/xilem/Cargo.toml#L40 is having a `[[example]]` target, that has the right specifications for Wasm but has the same name and code.

It's an hack, probably I should add a comment to src/wasm_lib.rs documenting this.