### PR TITLE
Enable LTO and strip symbols in release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,10 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib"]
 
+[profile.release]
+lto = true
+strip = true
+
 [[example]]
 # crate-type can't be (at the moment) be overriden for specific targets
 # src/wasm_lib.rs forwards to src/lib.rs so that we can change from cdylib


### PR DESCRIPTION
Implements https://github.com/duckdb/extension-ci-tools/issues/107 just for this repo.

Unsure what's the rustacean way to have those settings be either imported from extension-ci-tools, or have them set on build (although that would likely override eventual other directions).

Possibly it's fine have each repo fine-grain what they want, so having it in the template.

---


Sizes uncompressed:
Linux 231KB -> 180KB
OSX 192KB -> 163KB
Wasm 49KB -> 38KB
Windows 158KB -> 139KB