### PR TITLE
Enable windows_amd64_{mingw,rtools}

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -20,4 +20,4 @@ jobs:
       ci_tools_version: main
       extension_name: rusty_quack
       extra_toolchains: rust;python3
-      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw;linux_amd64_musl'
+      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;linux_amd64_musl'


### PR DESCRIPTION
Now that https://github.com/duckdb/extension-ci-tools/pull/153 is merged, I think this template can support `windows_amd64_rtools` and `windows_amd64_mingw`. Please let me know if there are remaining issues before doing this pull request (I'm a very newbie to DuckDB's build system).