### PR TITLE
Invoke CI only on main branch

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -4,7 +4,9 @@
 name: Main Extension Distribution Pipeline
 on:
   push:
+    branches: [main]
   pull_request:
+    branches: [main]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
If I understand correctly, the current GitHub Actions setting invokes the check on all pushes to any branches. I think an ordinary user wants to run CI only on the main branch. (Is this configured so by some intension...?)