### PR TITLE
Re-enable WASM builds

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -21,4 +21,4 @@ jobs:
       ci_tools_version: v1.5-variegata
       extension_name: rusty_quack
       extra_toolchains: rust;python3
-      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;linux_amd64_musl'
+      exclude_archs: 'linux_amd64_musl'


### PR DESCRIPTION
The bindgen overflow that originally broke WASM builds was fixed in https://github.com/duckdb/duckdb-rs/pull/433 (merged 2025-02-24). Drop the `wasm_*` exclusion from CI.

Closes #13